### PR TITLE
Add highlighting on/off support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,18 @@ The current development location for this repo can be found in this
 
 ## Installation
 
-You can just drop the linuxsty.vim file in your ~/.vim/plugin directory. 
-Alternatively you can use the Git repository with a manager such as 
+You can just drop the linuxsty.vim file in your ~/.vim/plugin directory.
+Alternatively you can use the Git repository with a manager such as
 [Pathogen](https://github.com/tpope/vim-pathogen).
 
 ## Usage
 
-By default the Linux coding style is enabled for any file known to the Linux 
+By default the Linux coding style is enabled for any file known to the Linux
 project (C files, headers, patches, Kconfig, etc.).
 
-If you prefer a finer control and apply it only on some files, define 
-a "g:linuxsty_patterns" array in your vimrc and the style will be applied only 
-if the buffer's path matches one of the pattern. For instance, you can match 
+If you prefer a finer control and apply it only on some files, define
+a "g:linuxsty_patterns" array in your vimrc and the style will be applied only
+if the buffer's path matches one of the pattern. For instance, you can match
 only projects under /usr/src/ and /linux with the following:
 
     let g:linuxsty_patterns = [ "/usr/src/", "/linux" ]
@@ -41,13 +41,13 @@ vimrc:
 
     let g:linuxsty_save_path = 1
 
-If you want to enable the coding style on demand without checking the filetype, 
-you can use the :LinuxCodingStyle command. For instance, you can map it with 
+If you want to enable the coding style on demand without checking the filetype,
+you can use the :LinuxCodingStyle command. For instance, you can map it with
 the following in your vimrc:
 
     nnoremap <silent> <leader>a :LinuxCodingStyle<cr>
 
 ## License
 
-Copyright (c) Vivien Didelot. Distributed under the same terms as Vim itself. 
+Copyright (c) Vivien Didelot. Distributed under the same terms as Vim itself.
 See :help license.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ the following in your vimrc:
 
     nnoremap <silent> <leader>a :LinuxCodingStyle<cr>
 
+If you want to have highlighting for coding style errors turned off by default,
+you can define the following option in your vimrc:
+
+    let g:linuxsty_highlight_off = 1
+
+Moreover, the highlighting can be easily turned on/off via the
+`:LinuxCodingStyleHighlightOn` and `LinuxCodingStyleHighlightOff` commands.
+For instance, you may add the following mappings in your vimrc:
+
+    nnoremap <silent> <leader>he :LinuxCodingStyleHighlightOn<cr>
+    nnoremap <silent> <leader>hd :LinuxCodingStyleHighlightOff<cr>
+
 ## License
 
 Copyright (c) Vivien Didelot. Distributed under the same terms as Vim itself.

--- a/plugin/linuxsty.vim
+++ b/plugin/linuxsty.vim
@@ -20,6 +20,11 @@
 " vimrc.
 "
 "   let g:linuxsty_save_path = 1
+"
+" If you want to have highlighting for coding style errors turned off by
+" default, you can define the following option in your vimrc:
+"
+"   let g:linuxsty_highlight_off = 1
 
 if exists("g:loaded_linuxsty")
     finish
@@ -27,6 +32,7 @@ endif
 let g:loaded_linuxsty = 1
 
 let g:linuxsty_save_path = get(g:, 'linuxsty_save_path', 0)
+let g:linuxsty_highlight_off = get(g:, 'linuxsty_highlight_off', 0)
 
 set wildignore+=*.ko,*.mod.c,*.order,modules.builtin
 
@@ -109,6 +115,21 @@ function s:LinuxHighlighting()
     " something
     autocmd InsertEnter * match LinuxError /\s\+\%#\@<!$/
     autocmd InsertLeave * match LinuxError /\s\+$/
+
+    if (g:linuxsty_highlight_off)
+        call s:LinuxHighlightToggle(0)
+    endif
+endfunction
+
+command! LinuxCodingStyleHighlightOn call s:LinuxHighlightToggle(1)
+command! LinuxCodingStyleHighlightOff call s:LinuxHighlightToggle(0)
+
+function s:LinuxHighlightToggle(enabled)
+    if (a:enabled)
+        highlight clear LinuxError
+    else
+        highlight link LinuxError NONE
+    endif
 endfunction
 
 function s:PathExistInCacheFile(cache_file, path)


### PR DESCRIPTION
Add a new global flag `linuxsty_highlight_off` to allow having syntax error highlighting disabled by default.

Additionally, introduce the `:LinuxCodingStyleHighlight{On,Off}` commands providing on demand control of the highlighting.